### PR TITLE
Fixed the problem of "command" while opening an PTY

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,7 +50,7 @@ class Server (paramiko.ServerInterface):
     good_pub_key = paramiko.RSAKey(data=decodebytes(data))
 
     def __init__(self):
-        self.cmd = ""
+        self.command = ""
         self.username = ""
         self.password = ""
         self.term = "xterm-256color"


### PR DESCRIPTION
Error fixed:
[!] *** Caught exception: <type 'exceptions.AttributeError'>: 'Server' object has no attribute 'command'
Traceback (most recent call last):
  File "ssh-relay/server.py", line 218, in <module>
    if server.command != "":
AttributeError: 'Server' object has no attribute 'command'